### PR TITLE
Watch post changes

### DIFF
--- a/src/Bonnier/WP/Cxense/Models/Post.php
+++ b/src/Bonnier/WP/Cxense/Models/Post.php
@@ -9,17 +9,13 @@ class Post
 {
     public static function watch_post_changes(SettingsPage $settingsPage) {
 
-        add_action('admin_init', function() use($settingsPage) {
+        if( $settingsPage->get_enabled() ) {
 
-            if( $settingsPage->get_enabled() ) {
+            // Ping crawler when post is changed
+            add_action('save_post', [__CLASS__, 'update_post']);
+        }
 
-                // Ping crawler when post is changed
-                add_action('save_post', [__CLASS__, 'update_post']);
-            }
-
-            add_action('delete_post', [__CLASS__, 'delete_post']);
-
-        });
+        add_action('delete_post', [__CLASS__, 'delete_post']);
     }
 
     public static function update_post($postId) {

--- a/src/Bonnier/WP/Cxense/Services/CxenseApi.php
+++ b/src/Bonnier/WP/Cxense/Services/CxenseApi.php
@@ -59,15 +59,15 @@ class CxenseApi {
     public static function pingCrawler($postId, $delete = false)
     {
         if( !wp_is_post_revision($postId) && !wp_is_post_autosave($postId) ) {
-            
+
             $contentUrl = is_numeric($postId) ? get_permalink($postId) : $postId;
-            
+
             $apiPath = $delete || ! Post::is_published($postId) ? self::CXENSE_PROFILE_DELETE : self::CXENSE_PROFILE_PUSH;
-            
+
             try {
-                
+
                 return self::request($apiPath, ['url'=> $contentUrl]);
-                
+
             } catch(Exception $e) {
 
                 if($e instanceof HttpException) {

--- a/wp-cxense.php
+++ b/wp-cxense.php
@@ -88,7 +88,7 @@ class Plugin
         $this->settings = new SettingsPage();
     }
 
-    private function boostrap() {
+    private function bootstrap() {
 
         Post::watch_post_changes($this->settings);
         Scripts::bootstrap($this->settings);
@@ -104,7 +104,7 @@ class Plugin
             self::$instance = new self;
             global $wp_cxense;
             $wp_cxense = self::$instance;
-            self::$instance->boostrap();
+            self::$instance->bootstrap();
 
             /**
              * Run after the plugin has been loaded.


### PR DESCRIPTION
save_post and delete_post are not always loaded during admin_init - it could happen before admin_init has even been called. Instead call this outside of the admin_init action.
