### PR TITLE
FORD-156/fix-delete

### DIFF
--- a/src/Bonnier/WP/Cxense/Models/Post.php
+++ b/src/Bonnier/WP/Cxense/Models/Post.php
@@ -19,14 +19,13 @@ class Post
 
     public static function post_status_changed($new_status, $old_status, $post)
     {
-        if($old_status === 'draft' && $new_status === 'trash') {
+        if ($old_status === 'draft' && $new_status === 'trash') {
             return;
         }
 
-        if($new_status === 'publish'){
+        if ($new_status === 'publish') {
             self::update_post($post->ID);
-        }
-        elseif($new_status === 'trash'){
+        } elseif ($new_status === 'trash') {
             self::delete_post($post->ID);
         }
     }

--- a/src/Bonnier/WP/Cxense/Models/Post.php
+++ b/src/Bonnier/WP/Cxense/Models/Post.php
@@ -14,8 +14,21 @@ class Post
         self::$settings = $settingsPage;
 
         // Ping crawler when post is changed
-        add_action('save_post', [__CLASS__, 'update_post']);
-        add_action('delete_post', [__CLASS__, 'delete_post']);
+        add_action('transition_post_status', [__CLASS__, 'post_status_changed'], 10, 3);
+    }
+
+    public static function post_status_changed($new_status, $old_status, $post)
+    {
+        if($old_status === 'draft' && $new_status === 'trash') {
+            return;
+        }
+
+        if($new_status === 'publish'){
+            self::update_post($post->ID);
+        }
+        elseif($new_status === 'trash'){
+            self::delete_post($post->ID);
+        }
     }
 
     public static function update_post($postId)

--- a/src/Bonnier/WP/Cxense/Services/CxenseApi.php
+++ b/src/Bonnier/WP/Cxense/Services/CxenseApi.php
@@ -63,7 +63,7 @@ class CxenseApi
             $contentUrl = is_numeric($postId) ? get_permalink($postId) : $postId;
 
             try {
-                if(!is_plugin_active( 'wp-bonnier-cache/wp-bonnier-cache.php' )){
+                if (!is_plugin_active('wp-bonnier-cache/wp-bonnier-cache.php')) {
                     $apiPath = $delete || ! Post::is_published($postId) ? self::CXENSE_PROFILE_DELETE : self::CXENSE_PROFILE_PUSH;
                     return self::request($apiPath, ['url'=> $contentUrl]);
                 }

--- a/wp-cxense.php
+++ b/wp-cxense.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP cXense
- * Version: 1.1.23
+ * Version: 1.1.3
  * Plugin URI: https://github.com/BenjaminMedia/wp-cxense
  * Description: This plugin integrates your site with cXense by adding meta tags and calling the cXense api
  * Author: Bonnier - Alf Henderson


### PR DESCRIPTION
Use **transition_post_status** hook instead of delete_post & save_post :

- save_post : fires in different cases even when we don't actually save the post. e.g just pressing the 'Add new' post will fire save_post .. which makes a lot of unnecessary calls to inexistent URL's.

- delete_post : fires only when we delete the post from the trash. Once a post is moved to the trash WP addes '__trashed' to the permalink and the post will not be returned anymore by widgets. Which results in 404 for posts moved to trash. We need to call the delete endpoint when we move the post to trash. if the post is moved back to published we call update endpoint.

Cleanup cache logic. If Bonnier cache plugin is activated handle all the cache logic from there. Otherwise fallback to the plugin context and update only cxense.