### PR TITLE
Changed the custom taxonomies settting to a Searchable Taxonomies

### DIFF
--- a/src/Bonnier/WP/Cxense/Assets/Scripts.php
+++ b/src/Bonnier/WP/Cxense/Assets/Scripts.php
@@ -2,6 +2,7 @@
 
 namespace Bonnier\WP\Cxense\Assets;
 
+use Bonnier\WP\ContentHub\Editor\Models\WpTaxonomy;
 use Bonnier\WP\Cxense\Settings\SettingsPage;
 
 class Scripts
@@ -181,7 +182,7 @@ class Scripts
 
     private function get_custom_taxonomy_terms($postId, $recs_tags)
     {
-        $customTaxonomies = static::$settings->get_custom_taxonomies(get_locale());
+        $customTaxonomies = WpTaxonomy::get_custom_taxonomies()->pluck('machine_name')->toArray();
         foreach ($customTaxonomies as $customTaxonomy) {
             foreach (wp_get_post_terms($postId, $customTaxonomy) as $term) {
                 $recs_tags[$this->org_prefix . 'taxo-' . str_replace('_', '-', $customTaxonomy)] = $term->name;

--- a/src/Bonnier/WP/Cxense/Assets/Scripts.php
+++ b/src/Bonnier/WP/Cxense/Assets/Scripts.php
@@ -2,7 +2,7 @@
 
 namespace Bonnier\WP\Cxense\Assets;
 
-use Bonnier\WP\ContentHub\Editor\Models\WpTaxonomy;
+use Bonnier\WP\Cxense\Settings\Partials\CustomTaxonomiesSettings;
 use Bonnier\WP\Cxense\Settings\SettingsPage;
 
 class Scripts
@@ -182,7 +182,7 @@ class Scripts
 
     private function get_custom_taxonomy_terms($postId, $recs_tags)
     {
-        $customTaxonomies = WpTaxonomy::get_custom_taxonomies()->pluck('machine_name')->toArray();
+        $customTaxonomies = CustomTaxonomiesSettings::get_printable_taxonomies();
         foreach ($customTaxonomies as $customTaxonomy) {
             foreach (wp_get_post_terms($postId, $customTaxonomy) as $term) {
                 $recs_tags[$this->org_prefix . 'taxo-' . str_replace('_', '-', $customTaxonomy)] = $term->name;

--- a/src/Bonnier/WP/Cxense/Settings/Partials/CustomTaxonomiesSettings.php
+++ b/src/Bonnier/WP/Cxense/Settings/Partials/CustomTaxonomiesSettings.php
@@ -5,16 +5,25 @@ namespace Bonnier\WP\Cxense\Settings\Partials;
 class CustomTaxonomiesSettings
 {
     const SETTING_KEY = 'custom_taxonomies';
+    const DISABLED_TAXONOMIES = [
+        'post_tag',
+        'nav_menu',
+        'link_category',
+        'post_format',
+        'language',
+        'post_translations',
+        'term_language',
+        'term_translations',
+    ];
 
     public static function render($fieldName, $fieldValues)
     {
         $taxonomies = get_taxonomies();
-        $disabledTypes = ['category', 'post_tag'];
         $output = "";
 
         foreach ($taxonomies as $taxonomy) {
             $checked = isset($fieldValues[$taxonomy]) && $fieldValues[$taxonomy] == 1 ?  'checked' : '';
-            if (!in_array($taxonomy, $disabledTypes)) {
+            if (!in_array($taxonomy, static::DISABLED_TAXONOMIES)) {
                 $output .= "
                     <strong>$taxonomy:</strong> 
                     <input type='hidden' value='0' name='".$fieldName."[$taxonomy]'>

--- a/src/Bonnier/WP/Cxense/Settings/Partials/CustomTaxonomiesSettings.php
+++ b/src/Bonnier/WP/Cxense/Settings/Partials/CustomTaxonomiesSettings.php
@@ -48,4 +48,15 @@ class CustomTaxonomiesSettings
 
         return $sanitizedInput;
     }
+
+    public static function get_printable_taxonomies() {
+        $taxonomies = get_taxonomies();
+        $prinableTaxonomies = [];
+        foreach($taxonomies as $taxonomy) {
+            if (!in_array($taxonomy, static::DISABLED_TAXONOMIES) && $taxonomy !== 'category') {
+                $prinableTaxonomies[] = $taxonomy;
+            }
+        }
+        return $prinableTaxonomies;
+    }
 }

--- a/src/Bonnier/WP/Cxense/Settings/Partials/CustomTaxonomiesSettings.php
+++ b/src/Bonnier/WP/Cxense/Settings/Partials/CustomTaxonomiesSettings.php
@@ -49,10 +49,11 @@ class CustomTaxonomiesSettings
         return $sanitizedInput;
     }
 
-    public static function get_printable_taxonomies() {
+    public static function get_printable_taxonomies()
+    {
         $taxonomies = get_taxonomies();
         $prinableTaxonomies = [];
-        foreach($taxonomies as $taxonomy) {
+        foreach ($taxonomies as $taxonomy) {
             if (!in_array($taxonomy, static::DISABLED_TAXONOMIES) && $taxonomy !== 'category') {
                 $prinableTaxonomies[] = $taxonomy;
             }

--- a/src/Bonnier/WP/Cxense/Settings/SettingsPage.php
+++ b/src/Bonnier/WP/Cxense/Settings/SettingsPage.php
@@ -59,7 +59,7 @@ class SettingsPage
         ],
         CustomTaxonomiesSettings::SETTING_KEY => [
             'type' => 'callback',
-            'name' => 'Custom Taxonomies',
+            'name' => 'Searchable Taxonomies',
             'callback' => [CustomTaxonomiesSettings::class, 'render'],
             'sanitize_callback' => [CustomTaxonomiesSettings::class, 'sanitize_input']
 
@@ -270,7 +270,7 @@ class SettingsPage
         return $this->get_setting_value(WidgetSettings::SETTING_KEY, $locale) ?: [];
     }
 
-    public function get_custom_taxonomies($locale = null)
+    public function get_searchable_taxonomies($locale = null)
     {
         return array_keys($this->get_setting_value(CustomTaxonomiesSettings::SETTING_KEY, $locale) ?: []);
     }

--- a/wp-cxense.php
+++ b/wp-cxense.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP cXense
- * Version: 1.2.0
+ * Version: 1.2.1
  * Plugin URI: https://github.com/BenjaminMedia/wp-cxense
  * Description: This plugin integrates your site with cXense by adding meta tags and calling the cXense api
  * Author: Bonnier - Alf Henderson


### PR DESCRIPTION
## Changes
- The plugin now always prints out all custom taxonomies as meta tags in the HTML in order to allow cXense to index everything
- The Searchable taxonomies setting is now used to toggle what facets should be displayed