### PR TITLE
WILL-56/fix-multi-select-search

### DIFF
--- a/src/Bonnier/WP/Cxense/Assets/Scripts.php
+++ b/src/Bonnier/WP/Cxense/Assets/Scripts.php
@@ -183,11 +183,20 @@ class Scripts
     private function get_custom_taxonomy_terms($postId, $recs_tags)
     {
         $customTaxonomies = CustomTaxonomiesSettings::get_printable_taxonomies();
+
         foreach ($customTaxonomies as $customTaxonomy) {
-            foreach (wp_get_post_terms($postId, $customTaxonomy) as $term) {
-                $recs_tags[$this->org_prefix . 'taxo-' . str_replace('_', '-', $customTaxonomy)] = $term->name;
+
+            $customTaxonomyKey = $this->org_prefix . 'taxo-' . str_replace('_', '-', $customTaxonomy);
+
+            if ($customTaxonomyTerms = wp_get_post_terms($postId, $customTaxonomy)) {
+                $recs_tags[$customTaxonomyKey] = [];
+            }
+
+            foreach ($customTaxonomyTerms as $term) {
+                array_push($recs_tags[$customTaxonomyKey], $term->name);
             }
         }
+
         return $recs_tags;
     }
 

--- a/src/Bonnier/WP/Cxense/Assets/Scripts.php
+++ b/src/Bonnier/WP/Cxense/Assets/Scripts.php
@@ -185,7 +185,6 @@ class Scripts
         $customTaxonomies = CustomTaxonomiesSettings::get_printable_taxonomies();
 
         foreach ($customTaxonomies as $customTaxonomy) {
-
             $customTaxonomyKey = $this->org_prefix . 'taxo-' . str_replace('_', '-', $customTaxonomy);
 
             if ($customTaxonomyTerms = wp_get_post_terms($postId, $customTaxonomy)) {

--- a/wp-cxense.php
+++ b/wp-cxense.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP cXense
- * Version: 1.2.7
+ * Version: 1.2.8
  * Plugin URI: https://github.com/BenjaminMedia/wp-cxense
  * Description: This plugin integrates your site with cXense by adding meta tags and calling the cXense api
  * Author: Bonnier - Alf Henderson


### PR DESCRIPTION
This will make sure we have an array whenever we have a custom taxonomy with multiple values. The array, later will be split to display values for cxense in the header. The output will be something like:

< meta name="cXenseParse:bod-taxo-operating-systems" content="Windows 10">
< meta name="cXenseParse:bod-taxo-operating-systems" content="Windows 7">
< meta name="cXenseParse:bod-taxo-operating-systems" content="Windows 8">

etc ..