### PR TITLE
IFD-415/wrong-cxense-metatag

### DIFF
--- a/src/Services/DocumentSearch.php
+++ b/src/Services/DocumentSearch.php
@@ -61,7 +61,9 @@ class DocumentSearch
             'recipe-meta-time-unit',
             'video-meta-duration',
             'video-meta-workout-time',
-            'video-meta-workout-level'
+            'video-meta-workout-level',
+            'commercial-label',
+            'commercial-format'
         ],
         'generic' => [
             'author',
@@ -69,8 +71,6 @@ class DocumentSearch
             'title',
             'click_url',
             'url',
-            'bod-commercial-label',
-            'bod-commercial-format',
             'dominantimage',
             'dominantthumbnail',
             'recs-publishtime',

--- a/wp-cxense.php
+++ b/wp-cxense.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP cXense
- * Version: 3.2.4
+ * Version: 3.2.5
  * Plugin URI: https://github.com/BenjaminMedia/wp-cxense
  * Description: This plugin integrates your site with cXense by adding meta tags and calling the cXense api
  * Author: Bonnier - Alf Henderson


### PR DESCRIPTION
moving bod-commercial-label and bod-commercial-format to organisation fields where prefix is dynamic